### PR TITLE
Fix seafile-entrypoint, MYSQL_SERVER default empty if not set

### DIFF
--- a/image/seafile/scripts/seafile-entrypoint.sh
+++ b/image/seafile/scripts/seafile-entrypoint.sh
@@ -98,15 +98,12 @@ choose_setup() {
   rm -f ${BASEPATH}/seafile-server-latest
 
   echo $VERSION > $DATADIR/current_version.tmp
-  set +u
   # If $MYSQL_SERVER is set, we assume MYSQL setup is intended,
   # otherwise sqlite
-  if [ -n "${MYSQL_SERVER}" ]
+  if [ -n "${MYSQL_SERVER:-}" ]
   then
-    set -u
     setup_mysql
   else
-    set -u
     setup_sqlite
   fi
   echo "Setup finished, storing current version $VERSION"
@@ -398,7 +395,7 @@ maintenance(){
 }
 
 wait_for_db(){
-  if [ -n "${MYSQL_SERVER}" ]; then
+  if [ -n "${MYSQL_SERVER:-}" ]; then
     # Wait for MySQL to boot up
     DOCKERIZE_TIMEOUT=${DOCKERIZE_TIMEOUT:-"60s"}
     dockerize -timeout ${DOCKERIZE_TIMEOUT} -wait tcp://${MYSQL_SERVER}:${MYSQL_PORT:-3306}


### PR DESCRIPTION
Hi there,

Minor fix in `seafile-entrypoint.sh`.
Hope you like it.

## Issue:
Not specifying envvar `MYSQL_SERVER`, should default to the use of sqlite.
When starting `seafile-ce` stand-alone with the (documented) minimal variables, starting docker image fails with:
```
/scripts/seafile-entrypoint.sh: line 401: MYSQL_SERVER: unbound variable 
Unclean shutdown: 1 , occurred on line 1 
```

Due to set -u in most of the script, any bash variable referenced that is not set will yield an error and `trap` will kick in.  
When `MYSQL_SERVER` is not set, the if clause in `wait_for_db()` (line 401)

## Fix
In relevant locations have `MYSQL_SERVER` var return a default if not set.  
- Line 401 is main change.
- Noticed a similar situation in `choose_setup()` function, where `set +u`/`set -u` were there as an alternative fix. Might as well keep it similar.

## Notes
- Why not just set an empty variable? `MYSQL_SERVER=""`  -> Several docker UI managers don't allow setting an empty variable, making this docker image impossible to use in those cases =\
- Why not use `set +u`/`set -u`? -> This seemed like the more elegant way to do it.